### PR TITLE
add limit-marker to ~a calls

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -7,6 +7,8 @@
          "boundary-view.rkt" "module-graph-view.rkt"
          (for-syntax racket/base syntax/parse))
 
+(define limit-dots " ... ")
+
 ;; (listof (U blame? #f)) profile-samples -> contract-profile struct
 (define (correlate-contract-samples contract-samples* samples*)
   ;; car of samples* is total time, car of each sample is thread id
@@ -87,9 +89,12 @@
     (make-srcloc-shortener all-blames blame-source))
   (define (format-contract/loc c s)
     (string-append
-     (~a (blame-contract c) #:width location-width)
+     (~a (blame-contract c) #:limit-marker limit-dots #:width location-width)
      (~a (format-samples-time s) "\n")
-     (~a (srcloc->string (shorten-source c)) #:width location-width)))
+     (~a (srcloc->string (shorten-source c))
+         #:limit-marker limit-dots
+         #:limit-prefix? #t
+         #:width (- location-width 1))))
   (define (format-samples-time s)
     (format "~a ms" (~r (samples-time s) #:precision 2)))
 
@@ -107,7 +112,7 @@
                           (blame-value (car x))) ; callee source, maybe
                         g)
               > #:key length)])
-      (display (~a "    " (blame-value (caar x)) #:width location-width))
+      (display (~a "    " (blame-value (caar x)) #:limit-marker limit-dots #:width location-width))
       (displayln (format-samples-time x)))
     (newline))
 

--- a/utils.rkt
+++ b/utils.rkt
@@ -139,7 +139,10 @@
     (for/hash ([p srcs]
                [e extracted])
       (values p (hash-ref shortened e (lambda () p)))))
-  (lambda (p)
+  (lambda (arg)
+    (define p (if (and (blame? arg) (blame-swapped? arg))
+                (blame-swap arg)
+                arg))
     (define target (hash-ref table p #f))
     (if target
         (struct-copy srcloc


### PR DESCRIPTION
Currently uses "....", not sure if that's the best choice.

Example output:

```
  cpu time: 2403 real time: 2403 gc time: 194
  Running time is 30.4% contracts
  816/2683 ms

  (-> (vectorof Integer) (-> (vectorof Integer) any) Array?)       135 ms
  /home/ben/code/racket/benchmark/gradual-typing-performance/b....
      unsafe-build-array                                           135 ms

  (-> (vectorof Integer) Integer (box/c (or/c #f #t)) (-> Void.... 30 ms
  data.rkt:8:10
      Array                                                        30 ms
```