### PR TITLE
Add instantiation-only mode to command-line interface

### DIFF
--- a/raco-tests.rkt
+++ b/raco-tests.rkt
@@ -1,0 +1,14 @@
+#lang racket/base
+
+(require rackunit)
+(require racket/system
+        racket/port
+        math/statistics)
+
+(define (get-total-time profiling-command)
+  (string->number (car (regexp-match #rx"[0-9]+" (car (regexp-match #rx"/[0-9]+ ms" (with-output-to-string (lambda () (system profiling-command)))))))))
+
+(for ([i (in-range 5)])
+   (define whole-time (get-total-time "racket raco.rkt test-inputs/main.rkt"))
+   (define instantiation-only-time (get-total-time "racket raco.rkt --instantiation-only test-inputs/main.rkt"))
+   (check-true (> whole-time instantiation-only-time)))

--- a/raco.rkt
+++ b/raco.rkt
@@ -12,6 +12,8 @@
 (define boundary-view-file #f)
 (define boundary-view-key-file #f)
 (define report-space-efficient? #f)
+(define instantiation-only? #f)
+
 (define file
   (command-line #:program (short-program+command-name)
                 #:once-each
@@ -27,8 +29,13 @@
                 [("--report-space-efficient")
                  "Distinguish space-efficient contracts from non"
                  (set! report-space-efficient? #t)]
+                [("--instantiation-only")
+                 "Exclude setup of module imports from measurements"
+                 (set! instantiation-only? #t)]
                 #:args (filename)
                 filename))
+
+(define visited-module (and instantiation-only? (module-to-profile file)))
 
 (collect-garbage)
 (collect-garbage)
@@ -39,6 +46,6 @@
  #:boundary-view-file boundary-view-file
  #:boundary-view-key-file boundary-view-key-file
  #:report-space-efficient? report-space-efficient?
- (dynamic-require (module-to-profile file) #f))
+ (dynamic-require (or visited-module (module-to-profile file)) #f))
 
 (module test racket/base) ; don't run for testing

--- a/scribblings/contract-profile.scrbl
+++ b/scribblings/contract-profile.scrbl
@@ -28,6 +28,10 @@ The simplest way to use this tool is to use the @exec{raco contract-profile}
 command, which takes a file name as argument, and runs the contract profiler on
 the @racket[main] submodule of that file (if it exists), or on the module
 itself (if there is no @racket[main] submodule).
+If the @exec{--instantiation-only} flag is given, only the instantiation of the
+module is profiled, and the profile will not include the module's initial
+visitation
+(see @secref["mod-parse" #:doc '(lib "scribblings/reference/syntax-model.scrbl")]).
 The tool's output is decribed below.
 }
 

--- a/test-inputs/main.rkt
+++ b/test-inputs/main.rkt
@@ -1,0 +1,4 @@
+#lang racket
+(require "u-module.rkt")
+
+(define result (u-decrement 2))

--- a/test-inputs/u-module.rkt
+++ b/test-inputs/u-module.rkt
@@ -1,0 +1,5 @@
+#lang racket
+
+(provide u-decrement)
+
+(define (u-decrement x) (- x 1))


### PR DESCRIPTION
Adds the flag `--instantiation-only` to the `raco contract-profile <flags> <filename>` interface. When this flag is set, the work of visiting `<filename>` (which include visiting and instantiating all of the modules specified in `<filename>`'s `require`-forms) is left out of the profile.